### PR TITLE
Translations update from Foundry Hub - Weblate

### DIFF
--- a/languages/zh_Hans.json
+++ b/languages/zh_Hans.json
@@ -42,6 +42,8 @@
 		},
 		"error": {
 			"cantFindToken": "无法找到指示物"
-		}
+		},
+		"removeTarget": "移除目标? [Ctrl-Click]",
+		"applied": "该目标已处理完毕。"
 	}
 }


### PR DESCRIPTION
Translations update from [Foundry Hub - Weblate](https://weblate.foundryvtt-hub.com) for [PF2e Target Damage/main](https://weblate.foundryvtt-hub.com/projects/pf2e-target-damage/main/).



Current translation status:

![Weblate translation status](https://weblate.foundryvtt-hub.com/widgets/pf2e-target-damage/-/main/horizontal-auto.svg)