### PR TITLE
Translations update from Foundry Hub - Weblate

### DIFF
--- a/languages/pl.json
+++ b/languages/pl.json
@@ -7,9 +7,9 @@
 		"splashButton": {
 			"radiusDialog": {
 				"title": "Zmień Zasięg",
-				"content": "Zasięg Plusku:"
+				"content": "Promień rozprysku:"
 			},
-			"hint": "[Klik] Wybierz tokeny dla obrażeń plusku.\n[Shift-Klik] Wyreguluj promień przed wybraniem."
+			"hint": "[Kliknij] Wybierz tokeny do zadania obrażeń rozpryskowych.\n[Shift-Click] Dostosuj promień przed wybraniem."
 		},
 		"hideButton": "Schowaj domyślne przyciski obrażeń.",
 		"settings": {

--- a/languages/pl.json
+++ b/languages/pl.json
@@ -46,6 +46,8 @@
 		"targetButton": {
 			"hint-false": "[Klik] Dodaj cele do wiadomości.\n[Shift-Klik] Wymień cele w wiadomości na teraźniejsze.",
 			"hint-true": "[Klik] Wymień cele w wiadomości na teraźniejsze.\n[Shift-Klik] Dodaj cele do wiadomości."
-		}
+		},
+		"removeTarget": "Usunąć cel? [Ctrl-Click]",
+		"applied": "Cel został przetworzony."
 	}
 }


### PR DESCRIPTION
Translations update from [Foundry Hub - Weblate](https://weblate.foundryvtt-hub.com) for [PF2e Target Damage/main](https://weblate.foundryvtt-hub.com/projects/pf2e-target-damage/main/).



Current translation status:

![Weblate translation status](https://weblate.foundryvtt-hub.com/widgets/pf2e-target-damage/-/main/horizontal-auto.svg)